### PR TITLE
Added userAgent properties

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -50,6 +50,7 @@ const openChatGPT = async (isChat?: boolean) => {
   });
 
   page.setViewport({ width, height });
+  page.setUserAgent('Mozilla/5.0 (Windows NT 5.1; rv:5.0) Gecko/20100101 Firefox/5.0'); // Added to by pass the bot detection by cloudflare
 
   await page.goto("https://chat.openai.com/", { waitUntil: "load" });
 


### PR DESCRIPTION
## What this PR do

Adding User-Agent properties in the headless browser to bypass cloudflare bot detection.

## How the implementations done

- add `setUserAgent` in the `openChatGPT` function with value `'Mozilla/5.0 (Windows NT 5.1; rv:5.0) Gecko/20100101 Firefox/5.0'`

## How to test

- Run locally and validate `TimeoutError: Waiting for selector 'textarea#prompt-textarea' failed: Waiting failed: 30000ms exceeded` won't show anymore